### PR TITLE
Add `FunPtr` support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,11 +16,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Build (--no-default-features)
-      run: cargo build --verbose --no-default-features
-    - name: Run tests (--no-default-features)
-      run: cargo test --verbose --no-default-features
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+    - name: Setup Nix
+      uses: cachix/install-nix-action@v20
+    - name: Enter Nix develop environment and build (--no-default-features)
+      run: nix develop --command cargo build --verbose --no-default-features
+    - name: Enter Nix develop environment and run tests (--no-default-features)
+      run: nix develop --command cargo test --verbose --no-default-features
+    - name: Enter Nix develop environment and run cargo clean
+      run: nix develop --command cargo clean
+    - name: Enter Nix develop environment and build
+      run: nix develop --command cargo build --verbose
+    - name: Enter Nix develop environment and run tests
+      run: nix develop --command cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "hs-bindgen-traits"
-version = "0.8.0"
+version = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "hs-bindgen-traits"
 repository = "https://github.com/yvan-sraka/hs-bindgen-traits"
 rust-version = "1.64.0"
-version = "0.8.0"
+version = "0.9.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685655444,
-        "narHash": "sha256-6EujQNAeaUkWvpEZZcVF8qSfQrNVWFNNGbUJxv/A5a8=",
+        "lastModified": 1688322751,
+        "narHash": "sha256-eW62dC5f33oKZL7VWlomttbUnOTHrAbte9yNUNW8rbk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e635192892f5abbc2289eaac3a73cdb249abaefd",
+        "rev": "0fbe93c5a7cac99f90b60bdf5f149383daaa615f",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1685759304,
-        "narHash": "sha256-I3YBH6MS3G5kGzNuc1G0f9uYfTcNY9NYoRc3QsykLk4=",
+        "lastModified": 1688438033,
+        "narHash": "sha256-wOmpZis06pVKTR+5meGwhrW10/buf98lnA26uQLaqek=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c535b4f3327910c96dcf21851bbdd074d0760290",
+        "rev": "c3e43223dece545cfe06ddd92fd782adc73d56c3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
         pkgs = import nixpkgs { inherit system overlays; };
       in with pkgs; {
         devShells.default = mkShell {
-          buildInputs = [ (rust-bin.fromRustupToolchainFile ./rust-toolchain) ];
+          buildInputs = [ (rust-bin.fromRustupToolchainFile ./rust-toolchain) rust-analyzer ];
         };
       });
 }

--- a/src/fun.rs
+++ b/src/fun.rs
@@ -1,0 +1,29 @@
+use crate::{private, FromReprRust};
+
+macro_rules! repr_rust_fn {
+    () => {
+        impl<Output> FromReprRust<unsafe extern "C" fn() -> Output> for Box<dyn Fn() -> Output>
+          where
+            Output: private::CFFISafe + 'static,
+        {
+            fn from(f: unsafe extern "C" fn() -> Output) -> Self {
+                unsafe { Box::new(move || f())}
+            }
+        }
+    };
+    ($x:ident, $y:ident $(,$xs:ident, $ys: ident)*) => {
+        repr_rust_fn!($( $xs, $ys ),*);
+        impl<$x, $($xs,)* Output> FromReprRust<unsafe extern "C" fn($x $(,$xs)*) -> Output> for Box<dyn Fn($x $(,$xs)*) -> Output>
+          where
+            Output: private::CFFISafe + 'static,
+            $x: private::CFFISafe + 'static$(,
+            $xs: private::CFFISafe + 'static)*
+        {
+            fn from(f: unsafe extern "C" fn($x $(, $xs )*) -> Output) -> Self {
+                unsafe { Box::new(move |$y $(,$ys)*| f($y $(,$ys)*))}
+            }
+        }
+    };
+}
+
+repr_rust_fn!(A, a, B, b, C, c, D, d, E, e, F, f);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@
 #![cfg_attr(not(feature = "std"), forbid(unsafe_code))]
 
 #[cfg(feature = "std")]
+mod fun;
+#[cfg(feature = "std")]
 mod str;
 #[cfg(feature = "std")]
 mod vec;
@@ -103,6 +105,23 @@ mod private {
 
     // C-FFI safe types (the previous macro avoid redundant code)
     c_ffi_safe![(), i8, i16, i32, i64, u8, u16, u32, u64, f32, f64];
+
+    macro_rules! c_ffi_safe_fun {
+        () => {
+            impl<Output: CFFISafe> CFFISafe for unsafe extern "C" fn() -> Output {}
+        };
+        ($x:ident $(,$xs:ident)*) => {
+            c_ffi_safe_fun!($( $xs ),*);
+            impl<$x $(,$xs)*, Output> CFFISafe for unsafe extern "C" fn($x, $($xs),*) -> Output
+              where
+               Output: CFFISafe,
+               $x: CFFISafe,
+               $($xs: CFFISafe),
+               * {}
+        };
+    }
+
+    c_ffi_safe_fun!(A, B, C, D, E, F);
 }
 
 macro_rules! transparent {


### PR DESCRIPTION
I've added support for FunPtr for passing haskell functions as arguments to the Rust FFI.
Depends on yvan-sraka/hs-bindgen-types#5 and yvan-sraka/hs-bindgen-attribute#1