### PR TITLE
Give traits less ambiguous (and more verbose) names

### DIFF
--- a/src/str.rs
+++ b/src/str.rs
@@ -1,18 +1,18 @@
 //! This module defines convenient traits to let user-defined function take as
 //! argument or return type either `CString`, `&CStr`, `String` or `&str`
 
-use crate::{ReprC, ReprRust};
+use crate::{FromReprC, FromReprRust};
 use std::ffi::{c_char, CStr, CString};
 
-impl ReprRust<*const c_char> for CString {
+impl FromReprRust<*const c_char> for CString {
     #[inline]
     fn from(ptr: *const c_char) -> Self {
-        let r: &str = ReprRust::from(ptr);
+        let r: &str = FromReprRust::from(ptr);
         CString::new(r).unwrap()
     }
 }
 
-impl ReprRust<*const c_char> for &CStr {
+impl FromReprRust<*const c_char> for &CStr {
     #[inline]
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     fn from(ptr: *const c_char) -> Self {
@@ -20,23 +20,23 @@ impl ReprRust<*const c_char> for &CStr {
     }
 }
 
-impl ReprRust<*const c_char> for String {
+impl FromReprRust<*const c_char> for String {
     #[inline]
     fn from(ptr: *const c_char) -> Self {
-        let r: &str = ReprRust::from(ptr);
+        let r: &str = FromReprRust::from(ptr);
         r.to_string()
     }
 }
 
-impl ReprRust<*const c_char> for &str {
+impl FromReprRust<*const c_char> for &str {
     #[inline]
     fn from(ptr: *const c_char) -> Self {
-        let r: &CStr = ReprRust::from(ptr);
+        let r: &CStr = FromReprRust::from(ptr);
         r.to_str().unwrap()
     }
 }
 
-impl ReprC<CString> for *const c_char {
+impl FromReprC<CString> for *const c_char {
     #[inline]
     fn from(s: CString) -> Self {
         let x = s.as_ptr();
@@ -48,16 +48,16 @@ impl ReprC<CString> for *const c_char {
     }
 }
 
-impl ReprC<String> for *const c_char {
+impl FromReprC<String> for *const c_char {
     #[inline]
     fn from(s: String) -> Self {
-        ReprC::from(CString::new(s).unwrap())
+        FromReprC::from(CString::new(s).unwrap())
     }
 }
 
 #[test]
 fn _1() {
     let x = "hello"; // FIXME: use Arbitrary crate
-    let y: &str = ReprRust::from(ReprC::from(x.to_string()));
+    let y: &str = FromReprRust::from(FromReprC::from(x.to_string()));
     assert!(x == y);
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,10 +1,10 @@
-use crate::{private, ReprC, ReprRust};
+use crate::{private, FromReprC, FromReprRust};
 
 // FIXME: study what could be a good `Vec<T>`/`&[T]` traits ergonomics ...
 // n.b. the concept of `slice` have no C equivalent ...
 // https://users.rust-lang.org/t/55118
 
-impl<T, const N: usize> ReprRust<*const T> for &[T; N]
+impl<T, const N: usize> FromReprRust<*const T> for &[T; N]
 where
     *const T: private::CFFISafe,
 {
@@ -19,13 +19,13 @@ where
     }
 }
 
-impl<T> ReprC<Vec<T>> for *const T
+impl<T> FromReprC<Vec<T>> for *const T
 where
     *const T: private::CFFISafe,
 {
     #[inline]
     fn from(v: Vec<T>) -> Self {
-        let x = v.as_ptr();
+        let x: *const T = v.as_ptr();
         // since the value is passed to Haskell runtime we want Rust to never
         // drop it!
         std::mem::forget(v);
@@ -41,6 +41,6 @@ where
 #[test]
 fn _1() {
     let x = &[1, 2, 3]; // FIXME: use Arbitrary crate
-    let y: &[i32; 3] = ReprRust::from(ReprC::from(x.to_vec()));
+    let y: &[i32; 3] = FromReprRust::from(FromReprC::from(x.to_vec()));
     assert!(x == y);
 }


### PR DESCRIPTION
**:warning: This is a BREAKING change** due to the renaming of traits:

- `ReprRust` → `FromReprRust`
- `ReprC`    → `FromReprC`

The new naming scheme enables us to define the dual traits `IntoReprC` and `IntoReprRust` more intuitively. Users are no longer required to assume the previously chosen default behavior. The new trait names align more closely with those defined in the standard library reducing potential confusion.

After experimenting with various strategies (such as implementing `From` and `Into` from `std` for some `ReprRust` and `ReprC` empty struct used as markers, and playing with `PhantomData`, `static` lifetimes), I've concluded that the simplest solution (as I want to forbid dynamic dispatch) is here the best.